### PR TITLE
Two traits

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run PHPStan
         run: |
           composer require --dev pestphp/pest
-          phpstan
+          phpstan analyze -v
 
       - name: Run Composer Dependency Analyser
         run: |

--- a/src/EnumConcern.php
+++ b/src/EnumConcern.php
@@ -13,6 +13,8 @@ trait EnumConcern
 {
     /**
      * Check if the current enum is a BackedEnum.
+     *
+     * @ phpstan-assert-if-true \BackedEnum $this
      */
     public static function isBackedEnum(): bool
     {
@@ -50,10 +52,10 @@ trait EnumConcern
      */
     public static function toArray(): array
     {
-        /** @var array<string, string|int> $result */
-        $result = self::toKeyValueCollection()->toArray();
-
-        return $result;
+        return array_combine(
+            array_column(self::cases(), 'name'),
+            array_column(self::cases(), 'value')
+        );
     }
 
     /**
@@ -61,7 +63,7 @@ trait EnumConcern
      */
     public static function toCollection(): Collection
     {
-        return collect(self::cases());
+        return new Collection(self::cases());
     }
 
     /**
@@ -120,7 +122,7 @@ trait EnumConcern
      */
     public static function hasName(string $name): bool
     {
-        return self::names()->contains($name);
+        return defined("self::{$name}");
     }
 
     /**


### PR DESCRIPTION
This is not a PR but the way I've struggled to reach 0 PHPStan errors.

At the first glance it looks efficient to implement enum concerns in one trait but pure enums and backed enums are so different!

```php
trait UnitEnumConcern
{}

trait BackedEnumConcern
{
    use UnitEnumConcern;
}
```

What do you think?
